### PR TITLE
 Add installation guides, add FAQs, update index page for GNU Guix

### DIFF
--- a/content/guix/faqs.org
+++ b/content/guix/faqs.org
@@ -1,0 +1,85 @@
+#+TITLE: FAQs
+#+AUTHOR: Daniel Rose
+
+Questions regarding Guix as an OS, Guix as a package manager, and the wiki itself.
+
+* Table of Contents :toc:
+- [[#what-is-gnu-guix][What is GNU Guix?]]
+- [[#should-i-use-the-package-manager-or-the-os][Should I use the package manager or the OS?]]
+- [[#how-do-i-install-guix][How do I install Guix?]]
+- [[#but-how-do-i-work-with-only-free-software][But how do I work with only free software?]]
+- [[#what-is-a-declarative-configuration][What is a declarative configuration?]]
+- [[#what-are-the-differences-between-guix-and-nix][What are the differences between Guix and Nix?]]
+- [[#im-stuck-where-do-i-ask-for-help][I'm stuck! Where do I ask for help?]]
+
+* What is GNU Guix?
+
+GNU Guix (or simply Guix) is a liberating, dependable, and hackable
+GNU/Linux distro configured using Guile Scheme. It is liberating
+because by default it uses only free software, and the Linux libre
+kernel. It is dependable because it is reproducable, supports
+rollbacks through "generations," and has transactional upgrades (as
+well as much more), and is hackable because it has Guile Scheme APIs
+for the entire system and packages.
+
+More practically, this means that Guix is configurable in your
+dotfiles (your GNU/Linux preferences, nicknamed dotfiles because they
+often start with a period) and are reproducable on all your
+machines. Your configuration can be copied across them all, and kept
+in version control (such as git).
+
+* Should I use the package manager or the OS?
+
+You can install Guix either as an OS or as a package manager in a
+foreign distribution of GNU/Linux. There are benefits to both, however
+if you truly want to reap all the benefits of Guix, you should use it
+as an OS. The choice is up to you.
+
+* How do I install Guix?
+
+If installing as a package manager, Guix can be downloaded as a binary
+from the official website at [[https://guix.gnu.org/download][guix.gnu.org]], from your distro's package
+repositories, or using the [[https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh][shell installer script]].
+
+If installing as an OS, you can go back to the System Crafters main
+wiki page for GNU Guix to see the options between nonguix and normal
+installation.
+
+* But how do I work with only free software?
+
+Well, you find alternatives! The FSF has a great article about this
+(written specifically for the COVID-19 pandemic, but always
+applicable): [[https://www.fsf.org/blogs/community/better-than-zoom-try-these-free-software-tools-for-staying-in-touch][free software alternatives]]. For other general things,
+consider LibreOffice for Microsoft Office, Gimp for Photoshop,
+Inkscape for Illustrator, and there are many other good alternatives
+to look for that respect your freedom.
+
+That said, we all have programs that we need for work that aren't free
+(and if you don't, consider yourself lucky.) Guix System, the name for
+the OS version, has options for nonfree software, such as nonguix,
+Nix, and Flatpak.
+
+* What is a declarative configuration?
+
+A declarative configuration is, put simply, when you write out your
+settings and packages instead of running a command. This allows for
+reproducability, and easier management of installed packages. Think of
+it as declaring what you are going to do before doing it, as opposed
+to doing it without writing it down or alerting people.
+
+* What are the differences between Guix and Nix?
+
+First and foremost, Guix is configured in Guile Scheme, a Scheme
+(which in itself is a Lisp), while Nix is configured in... Nix. A bit
+confusing :smile:. Guile Scheme is a full fledged Scheme programming
+language, which means you can do some powerful things in it. Packages
+as well as system configurations are written in Guile in Guix. Guile
+also has more unified commands, while Nix has many for different
+purposes.
+
+* I'm stuck! Where do I ask for help?
+
+Check out one of the System Crafters channels on Discord, IRC, and
+Matrix. You can also watch some of the System Crafters videos, read
+this wiki, or ask in ~#guix~ for free and ~#nonguix~ for nonfree on
+IRC.

--- a/content/guix/general-recommendations.org
+++ b/content/guix/general-recommendations.org
@@ -1,0 +1,25 @@
+#+TITLE: General Recommendations
+#+AUTHOR: Daniel Rose
+
+The following are recommendations for your new Guix system. Some are
+nonfree, these are indicated with a bold *NF* next to the heading.
+
+* Table of Contents :toc:
+- [[#desktop-environments-and-window-managers][Desktop Environments and Window Managers]]
+
+* Desktop Environments and Window Managers
+
+More likely than not, you want to install a window manager or desktop
+environment. KDE is /not/ installable on Guix due to numerous issues,
+XFCE would be a good alternative to look at.
+
+Quite a few window managers have built in support:
+- i3
+- EXWM
+- dwm
+- Xmonad
+- StumpWM
+
+There are also desktop environments for those who prefer them:
+- XFCE
+- GNOME

--- a/content/guix/index.org
+++ b/content/guix/index.org
@@ -1,3 +1,37 @@
-#+title: GNU Guix
+#+TITLE: GNU Guix
 
-* TODO Add content!
+/A liberating, dependable, and hackable functional OS and package manager./
+
+* Welcome to the System Crafters' Community GNU Guix Wiki!
+
+GNU Guix is a functional, reproducible GNU/Linux package manager and
+OS. A free (as in freedom), Guile Scheme based alternative to Nix,
+Guix provides the power of a functional OS and more. While powerful,
+many of Guix's configurations and options seem arcane and
+inaccessible. This wiki is here to show that the complete opposite is
+true!
+
+** Why if so many other places (and the manual) exist?
+
+Truthfully, there aren’t that many other places. The System Crafters'
+wiki is attempting to enable more people to use GNU Guix with free and
+non-free software. The community should understand and be open to the
+fact that not all can realistically use only free software; this is
+not to say that the FSF is wrong or bad, but that we should ease
+people into using free as in freedom software and utilities. The
+System Crafters community believes there is a lot we can do to improve
+the experience for all.
+
+** Where to start?
+
+If you've never used or heard of GNU Guix, you should start at "FAQs"
+<placeholder>. If you've used Nix before, or are feeling courageous,
+start right away at "Installation Guide" <placeholder> if you want a
+fully free experience, or if you are not sure what that means or want
+nonfree (recommended choice), start at the "Nonguix Installation
+Guide."
+
+** Featured News and Articles
+
+*TODO:* Possibly randomly select articles here, or show commonly
+ sought after things (Firefox, Nix.)

--- a/content/guix/index.org
+++ b/content/guix/index.org
@@ -29,9 +29,9 @@ If you've never used or heard of GNU Guix, you should start at "FAQs"
 start right away at "Installation Guide" <placeholder> if you want a
 fully free experience, or if you are not sure what that means or want
 nonfree (recommended choice), start at the "Nonguix Installation
-Guide."
+Guide." <placeholder>
 
 ** Featured News and Articles
 
-*TODO:* Possibly randomly select articles here, or show commonly
+*** TODO Possibly randomly select articles here, or show commonly
  sought after things (Firefox, Nix.)

--- a/content/guix/index.org
+++ b/content/guix/index.org
@@ -24,12 +24,20 @@ the experience for all.
 
 ** Where to start?
 
-If you've never used or heard of GNU Guix, you should start at "FAQs"
-<placeholder>. If you've used Nix before, or are feeling courageous,
-start right away at "Installation Guide" <placeholder> if you want a
-fully free experience, or if you are not sure what that means or want
-nonfree (recommended choice), start at the "Nonguix Installation
-Guide." <placeholder>
+*** If you've never used or heard of GNU Guix
+
+you should start at [[/guix/faqs][FAQs]].
+
+*** If you've used Nix before, or are feeling courageous
+
+start right away at [[https://guix.gnu.org/manual/en/html_node/System-Installation.html][Official Installation Guide]] if you want a fully
+free experience, or if you are not sure what that means or want
+nonfree (recommended choice), start at the [[/guix/nonguix-installation-guide][Nonguix Installation Guide]].
+
+Note that the official installation guide is from the GNU Guix manual,
+and links to that site. It is still recommended to read [[/guix/general-recommendations][general
+recommendations]] afterwards, although you might not want to follow the
+nonfree advice on there.
 
 ** Featured News and Articles
 

--- a/content/guix/nonguix-installation-guide.org
+++ b/content/guix/nonguix-installation-guide.org
@@ -8,8 +8,7 @@ Linux kernel, as opposed to the libre one. This allows for more driver
 support, such as WiFi on many modern laptops, and makes the
 installation process much easier.
 
-Before installing, it would be advised to view the FAQ, and read up on
-the "What is GNU Guix?" <placeholder> page.
+Before installing, it would be advised to view the [[/guix/faqs][FAQs]].
 
 For installations of software and specific issues, please search for
 your topic or look in the categories.
@@ -20,14 +19,33 @@ guide assumes a working internet connection is available. The Nonguix
 installation medium should cover WiFi issues normally present in the
 Guix installer.
 
+* Table of Contents :toc:
+- [[#pre-installation][Pre-installation]]
+  - [[#download-the-installation-image][Download the installation image]]
+  - [[#booting][Booting]]
+  - [[#connecting-to-the-internet][Connecting to the internet]]
+  - [[#partition-the-disks][Partition the disks]]
+- [[#installation][Installation]]
+  - [[#herd-store][Herd store]]
+  - [[#system-configuration][System configuration]]
+  - [[#channels][Channels]]
+  - [[#update-system-configuration][Update system configuration]]
+  - [[#initialize-system][Initialize system]]
+- [[#post-installation][Post-installation]]
+  - [[#user-accounts][User accounts]]
+  - [[#dotfiles][Dotfiles]]
+  - [[#channels-1][Channels]]
+  - [[#general-recommendations][General recommendations]]
+
 * Pre-installation
 
 ** Download the installation image
 
-The installation image is kept at "link to GitHub Workflow"
-<placeholder>. Burn this ISO to an installation medium (flash drive or
-DVD), and boot from it. For example, to burn it to a USB flash drive
-at `/dev/sdX`, run the following command:
+The installation image is kept at a repo in the System Crafters
+organization. Click [[https://github.com/SystemCrafters/guix-installer/releases/latest][here]] to download the latest ISO. Burn this ISO to
+an installation medium (flash drive or DVD), and boot from it. For
+example, to burn it to a USB flash drive at ~/dev/sdX~, run the
+following command:
 
 #+BEGIN_SRC sh
 dd if=guix-installer.iso of=/dev/sdX status=progress bs=4M
@@ -192,7 +210,7 @@ fdisk /dev/sdX
 Next, you should format your partitions with the correct file
 system. To create an Ext4 file system on ~/dev/root_partition~, run:
 
-,#+BEGIN_SRC sh
+#+BEGIN_SRC sh
 mkfs.ext4 /dev/root_partition
 #+END_SRC
 
@@ -376,6 +394,6 @@ guix pull
 You can now install whatever packages or manifests you need and
 have. If you are new to GNU Guix, continue reading at the "Basics of
 GNU GUIX" page <placeholder>. If interested in basic system setups and
-advice, continue reading at the "General recommendations" page
-<placeholder>. Otherwise, once again, congratulations!  You have
-officially installed a nonfree/nonguix Guix System!
+advice, continue reading at [[/guix/general-recommendations][general recommendations]]. Otherwise, once
+again, congratulations!  You have officially installed a
+nonfree/nonguix Guix System!

--- a/content/guix/nonguix-installation-guide.org
+++ b/content/guix/nonguix-installation-guide.org
@@ -36,6 +36,7 @@ Guix installer.
   - [[#dotfiles][Dotfiles]]
   - [[#channels-1][Channels]]
   - [[#general-recommendations][General recommendations]]
+- [[#further-reading][Further Reading]]
 
 * Pre-installation
 
@@ -397,3 +398,10 @@ GNU GUIX" page <placeholder>. If interested in basic system setups and
 advice, continue reading at [[/guix/general-recommendations][general recommendations]]. Otherwise, once
 again, congratulations!  You have officially installed a
 nonfree/nonguix Guix System!
+
+* Further Reading
+
+For more information, and to read the official installation guide,
+look at the following links:
+- [[https://guix.gnu.org/manual/devel/en/html_node/Installation.html#Installation][Installation in the Guix manual]]
+- [[https://gitlab.com/nonguix/nonguix/][Nonguix GitLab repository]]

--- a/content/guix/nonguix-installation-guide.org
+++ b/content/guix/nonguix-installation-guide.org
@@ -403,5 +403,5 @@ nonfree/nonguix Guix System!
 
 For more information, and to read the official installation guide,
 look at the following links:
-- [[https://guix.gnu.org/manual/devel/en/html_node/Installation.html#Installation][Installation in the Guix manual]]
+- [[https://guix.gnu.org/manual/devel/en/html_node/System-Installation.html#System-Installation][Installation in the Guix manual]]
 - [[https://gitlab.com/nonguix/nonguix/][Nonguix GitLab repository]]

--- a/content/guix/nonguix-installation-guide.org
+++ b/content/guix/nonguix-installation-guide.org
@@ -1,0 +1,381 @@
+#+TITLE: Nonguix Installation Guide
+#+AUTHOR: Daniel Rose
+
+This document is a guide for installing GNU Guix using the live system
+booted from a ~nonguix~ installation medium. The installation medium
+is provided by a GitHub Action from System Crafters, and uses the full
+Linux kernel, as opposed to the libre one. This allows for more driver
+support, such as WiFi on many modern laptops, and makes the
+installation process much easier.
+
+Before installing, it would be advised to view the FAQ, and read up on
+the "What is GNU Guix?" <placeholder> page.
+
+For installations of software and specific issues, please search for
+your topic or look in the categories.
+
+GNU Guix should run on most x86-64 compatible PCs. As the installation
+process needs to retrieve packages from a remote repository, this
+guide assumes a working internet connection is available. The Nonguix
+installation medium should cover WiFi issues normally present in the
+Guix installer.
+
+* Pre-installation
+
+** Download the installation image
+
+The installation image is kept at "link to GitHub Workflow"
+<placeholder>. Burn this ISO to an installation medium (flash drive or
+DVD), and boot from it. For example, to burn it to a USB flash drive
+at `/dev/sdX`, run the following command:
+
+#+BEGIN_SRC sh
+dd if=guix-installer.iso of=/dev/sdX status=progress bs=4M
+#+END_SRC
+
+** Booting
+
+Boot from the installation medium, select your language and country,
+and select "Install using the shell based process" when
+prompted. Although this makes the installation slightly more
+difficult, it allows for setting up your new installation with the
+full Linux kernel (necessary for the nonfree installation.)
+
+** Connecting to the internet
+
+If you have ethernet, simply plug in your cable and continue to the
+next step. If you have WiFi, use an editor (or ~echo~) to create a new
+file called ~wifi.conf~ to store the WiFi configuration. Make sure to
+set ~ssid~ to the name of your WiFi network name, and ~psk~ to the
+passphrase for your WiFi. You may also need to change the ~key_mgmt~
+parameter depending on the type of authentication your wifi router
+supports.
+
+#+BEGIN_SRC sh
+network={
+  ssid="ssid-name"
+  key_mgmt=WPA-PSK
+  psk="unencrypted passphrase"
+}
+#+END_SRC
+
+Next, run the following commands to unblock the WiFi card, determine
+its device name, and connect using the device name received. In the
+example, the name is ~wlp4s0~, so ~wpa_supplicant~ is passed the flag
+~-i wlp4s0~. Change this accordingly:
+
+#+BEGIN_SRC sh
+rfkill unblock all
+ifconfig -a
+wpa_supplicant -c wifi.conf -i wlp4s0 -B
+#+END_SRC
+
+#+BEGIN_QUOTE
+*NOTE:* If for any reason running =wpa_supplicant= fails, make sure to
+kill any background instances of it before trying to run it again
+because the old instances will block new runs from working.  This
+wasted a couple hours the first time I tried installing Guix!
+#+END_QUOTE
+
+Finally, run ~dhclient~ to turn on DNS, remembering to replace
+~wlp4s0~ with your device name returned from ~ifconfig -a~:
+
+#+BEGIN_SRC sh
+dhclient -v wlp4s0
+#+END_SRC
+
+** Partition the disks
+
+When disks are detected by the system, they are assigned a block
+device. To list these block devices, run ~lsblk~ or ~fdisk -l~.
+
+For example, running ~lsblk~ on my laptop returns these results:
+
+#+BEGIN_SRC sh
+$ lsblk
+
+NAME          MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
+sda             8:0    0 465.8G  0 disk
+├─sda1          8:1    0   549M  0 part  /boot/efi
+├─sda2          8:2    0 153.5G  0 part
+│ └─cryptroot 253:0    0 153.5G  0 crypt /
+└─sda3          8:3    0 311.7G  0 part
+  └─crypthome 253:1    0 311.7G  0 crypt /home
+sr0            11:0    1  1024M  0 rom
+#+END_SRC
+
+I have an encrypted root and home (if you don't know what that is,
+don't worry, it just means I have to put in two passwords before I can
+use my computer), so my devices might appear differently than yours,
+but the rough idea is the same. You might have no partitions (the
+numbered versions, such as ~/dev/sda1~) if you just wiped your drive,
+or many if you are coming from a different GNU/Linux OS or Windows.
+
+*** Encrypted
+
+If you would like to have encrypted block devices (entire partitions),
+use LUKS. If you do not want encryption, continue reading at
+"Regular."
+
+Your encrypted blocks can be all or none, however in this example only
+the root will be encrypted and UEFI will be used. If unsure, look at
+"Regular" and see the potential layouts (or read the linked article
+for the Arch Wiki there).
+
+| Mount point     | Partition                   | Partition type            | Suggested size              |
+|-----------------+-----------------------------+---------------------------+-----------------------------|
+| ~/mnt/boot/efi~ | ~/dev/efi_system_partition~ | EFI system partition      | At least 260 MiB            |
+| ~[SWAP]~        | ~/dev/swap_partition~       | Linux swap                | More than 512 MiB           |
+| ~/mnt~          | ~/dev/root_partition~       | Linux x86-64 root (/)     | Remainder of the device     |
+
+#+BEGIN_SRC sh
+cfdisk /dev/root_partition
+#+END_SRC
+
+Once your partitions are created, you can enable LUKS on the root
+partition by running the following commands. You can change
+~system-root~ to whatever you desire:
+
+#+BEGIN_SRC sh
+cryptsetup luksFormat /dev/root_partition
+cryptsetup open --type luks /dev/root_partition system-root
+mkfs.ext4 -L system-root /dev/mapper/system-root
+mount LABEL=system-root /mnt
+#+END_SRC
+
+Finally, ensure your EFI system partition and swap are both
+activated/mounted:
+
+#+BEGIN_SRC sh
+mkdir -p /mnt/boot/efi
+mount /dev/efi_system_partition /mnt/boot/efi
+
+swapon /dev/swap_partition
+#+END_SRC
+
+Proceed to "Installation."
+
+*** Regular
+
+If you would not like to have encrypted block devices (entire
+partitions), you can partition your drives just as you would for any
+other GNU/Linux OS. For example, you could have the following layout
+(as suggested by the Arch Wiki) if using UEFI (most modern computers):
+
+| Mount point     | Partition                   | Partition type            | Suggested size              |
+|-----------------+-----------------------------+---------------------------+----------------------------- |
+| ~/mnt/boot/efi~ | ~/dev/efi_system_partition~ | EFI system partition      | At least 260 MiB            |
+| ~[SWAP]~        | ~/dev/swap_partition~       | Linux swap                | More than 512 MiB           |
+| ~/mnt~          | ~/dev/root_partition~       | Linux x86-64 root (/)     | At least 1/3 of your device |
+| ~/mnt/home~     | ~/dev/home_partition~       | Linux x86-64 home (/home) | Remainder of the device     |
+
+For BIOS with MBR, the Arch Wiki suggests the following:
+
+| Mount point | Partition             | Partition type | Suggested size              |
+|-------------+-----------------------+----------------+-----------------------------|
+| ~[SWAP]~    | ~/dev/swap_partition~ | Linux swap     | More than 512 MiB           |
+| ~/mnt~      | ~/dev/root_partition~ | Linux          | At least 1/3 of your device |
+| ~/mnt/home~ | ~/dev/home_partition~ | Linux          | Remainder of the device     |
+
+Many other partitioning schemes exist: if you'd like to try other ones
+or learn about your options, check out the Arch Wiki's page for
+[[https://wiki.archlinux.org/title/Partitioning#Example_layouts][partitioning]].
+
+Partition your disks using either ~cfdisk~ or ~fdisk~:
+
+#+BEGIN_SRC sh
+cfdisk /dev/sdX
+
+fdisk /dev/sdX
+#+END_SRC
+
+Next, you should format your partitions with the correct file
+system. To create an Ext4 file system on ~/dev/root_partition~, run:
+
+,#+BEGIN_SRC sh
+mkfs.ext4 /dev/root_partition
+#+END_SRC
+
+To initialize swap, run the following command:
+
+#+BEGIN_SRC sh
+mkswap /dev/swap_partition
+#+END_SRC
+
+Now it is time to mount your partitions. This will change depending on
+your chosen layout, but all drives are mounted as such:
+
+#+BEGIN_SRC sh
+mount /dev/partition_name /mnt
+#+END_SRC
+
+Replace ~partition_name~ with the partition's name, and ~/mnt~ with
+the necessary location. The following locations are used:
+
+- Root partition: ~/mnt~
+- Home partition: ~/mnt/home~
+- EFI system partition: ~/mnt/boot/efi~
+
+In order to mount a partition, that directory (folder) needs to
+exist. For ~/mnt/home~ and ~/mnt/boot/efi~ (if created) create the
+directories as follows /after/ mounting ~/mnt~:
+
+#+BEGIN_SRC sh
+mkdir -p /mnt/boot/efi
+
+mkdir -p /mnt/home
+#+END_SRC
+
+Swap is activated with the ~swapon~ command:
+
+#+BEGIN_SRC sh
+swapon /dev/swap_partition
+#+END_SRC
+
+* Installation
+
+** Herd store
+
+Once all partitions are mounted, you can begin the
+installation. First, set up the installation environment using ~herd~:
+
+#+BEGIN_SRC sh
+herd start cow-store /mnt
+#+END_SRC
+
+** System configuration
+
+The following steps will change depending on your approach. If you've
+used Guix in the past and would like to use your dotfiles and system
+configuration (your custom configurations), clone your repository now.
+
+If you would like to make your own, you need to at least have the
+nonguix channels setup for the installation medium. If you aren't sure
+what that means, or how to do that yourself, follow the instructions
+below for now, only copying the ~channels.scm~.
+
+If you do not have personal dotfiles yet, and would like to try David
+Wilson's, clone the following repository using ~git~ into your current
+directory (i.e. not ~/mnt~):
+
+#+BEGIN_SRC sh
+git clone https://github.com/daviwil/dotfiles
+#+END_SRC
+
+** Channels
+
+Regardless of your path, you should now add the nonguix and necessary
+custom channels to the installation medium. Run the following commands
+to set up the necessary channels and run ~guix pull~ (equivalent to
+~apt update~, updates the files available without updating the ones on
+the system):
+
+#+BEGIN_SRC sh
+mkdir -p ~/.config/guix
+# If you cloned David Wilson's dotfiles:
+cp dotfiles/guix/channels.scm ~/.config/guix
+# Otherwise, add the channels.scm file yourself and edit it with nonguix and your necessary channels
+guix pull
+# This is necessary to ensure the updated profile path is active!
+hash guix
+#+END_SRC
+
+The pull operation can take quite a while, depending upon your machine
+and the last time the nonguix installation ISO was updated. I'd
+recommend getting a cup of coffee (or tea, or whatever your preferred
+beverage is!)
+
+** Update system configuration
+
+Once the operation is finished, you will need to update your
+configuration to point to your partition UUIDs and labels for the
+system that you are installing. In order to get your UUIDs, run the
+following command:
+
+#+BEGIN_SRC sh
+blkid
+#+END_SRC
+
+This will return a long list of IDs that you can write down, take a
+picture of, ~cat~ or ~echo~ into your configuration, depending on
+which is more comfortable to you (if you're not too familiar with
+GNU/Linux, I'd recommend writing the IDs down. They are long, but it
+is faster and safer in the long run.) You can also switch to another
+TTY using ~Ctrl-Alt-F#~ and press ~Enter~ or ~Return~ to get to
+another root prompt. You can then switch back and forth between the
+previous TTY on ~F3~ instead of writing down your IDs.
+
+If you have encrypted partitions, yyou can use the following command
+to find the UUID:
+
+#+BEGIN_SRC sh
+cryptsetup luksUUID /dev/root_partition
+#+END_SRC
+
+** Initialize system
+
+Finally, we can initialize the system by running the following command:
+
+#+BEGIN_SRC sh
+# Change the .dotfiles directory to your dotfiles if necessary
+guix system -L ~/.dotfiles/.config/guix/systems init path/to/config.scm /mnt
+#+END_SRC
+
+This can take a /very/ long time depending on your internet connection
+and computer. If using a laptop, please ensure it is plugged in. If
+any errors occur during the installation, simply resume the
+installation as the Guix store has the previous packages saved. If the
+error continues, consider contacting someone at the System Crafters'
+Discord, IRC, or Matrix "Links?" <placeholder>.
+
+* Post-installation
+
+** User accounts
+
+Congratulations! Your GNU Guix System installation is (almost)
+complete. Reboot your system, take out your installation medium, and
+login as root when you are faced with a login prompt. Your last
+crucial step is to add a password for your accounts. Once logged in,
+run the following commands:
+
+#+BEGIN_SRC sh
+# Set the password for your root account
+passwd
+# Set the password for your user
+passwd <your username>
+#+END_SRC
+
+Log out, and log into your user account.
+
+** Dotfiles
+
+Clone your dotfiles repository (or David Wilson's again) and ensure
+that the channels include nonguix. If using David Wilson's dotfiles,
+~cd~ into the directory and run:
+
+#+BEGIN_SRC sh
+stow .
+#+END_SRC
+
+If using your own dotfiles, you know how to deploy them. If you don't
+have a good way to deploy your dotfiles yet, consider using ~stow~
+"Link?" <placeholder>.
+
+** Channels
+
+Verify that your ~channels.scm~ file is in the target path
+(~\~/.config/guix~) and then run the following to update your
+channels:
+
+#+BEGIN_SRC sh
+guix pull
+#+END_SRC
+
+** General recommendations
+
+You can now install whatever packages or manifests you need and
+have. If you are new to GNU Guix, continue reading at the "Basics of
+GNU GUIX" page <placeholder>. If interested in basic system setups and
+advice, continue reading at the "General recommendations" page
+<placeholder>. Otherwise, once again, congratulations!  You have
+officially installed a nonfree/nonguix Guix System!

--- a/local-build.sh
+++ b/local-build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+emacs -q --batch -l ./publish.el --funcall dw/publish

--- a/publish.el
+++ b/publish.el
@@ -110,17 +110,22 @@
                                      (a (@ (class "nav-link") (href "/")) "Main Page") " "
                                      (a (@ (class "nav-link") (href "/emacs")) "GNU Emacs") " "
                                      (a (@ (class "nav-link") (href "/guix")) "GNU Guix")
-                                     (a (@ (class "nav-link") (href "https://systemcrafters.cc")) "System Crafters Home") " "))))))))))
+                                     (a (@ (class "nav-link") (href "https://systemcrafters.cc")) "System Crafters Home")
+                                     (form (@ (class "navbar-form navbar-right") (role "search") (action "https://duckduckgo.com/"))
+                                           (div (@ (class "form-group"))
+                                                (input (@ (type "text") (name "q") (class "form-control") (placeholder "Search Wiki") (style "overflow: hidden;margin-top: 3%;margin-bottom: 2%;")))
+                                                (input (@ (type "hidden") (name "sites") (value "wiki.systemcrafters.cc")))))
+                                     " "))))))))))
 
 (defun dw/site-footer (info)
   (concat
    ;; "</div></div>"
    (sxml-to-xml
     `(footer (@ (class "blog-footer"))
-      (div (@ (class "container"))
-           (div (@ (class "row"))
-                (div (@ (class "col-sm col-md text-sm-left text-md-right text-lg-right text-xl-right"))
-                     (p "Made with " ,(plist-get info :creator)))))))
+             (div (@ (class "container"))
+                  (div (@ (class "row"))
+                       (div (@ (class "col-sm col-md text-sm-left text-md-right text-lg-right text-xl-right"))
+                            (p "Made with " ,(plist-get info :creator)))))))
    (sxml-to-xml
     `(script (@ (src "/js/bootstrap.bundle.min.js"))))))
 
@@ -133,10 +138,10 @@
 
     (if (string-match "\\/index.org$" org-file)
         pub-dir
-        (progn
-          (unless (file-directory-p article-dir)
-            (make-directory article-dir t))
-          article-dir))))
+      (progn
+        (unless (file-directory-p article-dir)
+          (make-directory article-dir t))
+        article-dir))))
 
 (defun dw/org-html-template (contents info)
   (concat
@@ -161,28 +166,28 @@
                      (href "/css/site.css")))
             (title ,(concat (org-export-data (plist-get info :title) info) " - System Crafters")))
            (body
-             ,(dw/site-header info)
-             (div (@ (class "container"))
-                  (div (@ (class "row"))
-                       (div (@ (class "col-sm-12 blog-main"))
-                            (div (@ (class "blog-post"))
-                                 (h1 (@ (class "blog-post-title"))
-                                     ,(org-export-data (plist-get info :title) info))
-                                 (p (@ (class "blog-post-meta"))
-                                    ,(org-export-data (org-export-get-date info "%B %e, %Y") info))
-                                 ,contents
-                                 ,(let ((tags (plist-get info :filetags)))
-                                    (when (and tags (> (list-length tags) 0))
-                                      `(p (@ (class "blog-post-tags"))
-                                          "Tags: "
-                                          ,(mapconcat (lambda (tag) tag)
-                                                        ;; TODO: We don't have tag pages yet
-                                                        ;; (format "<a href=\"/tags/%s/\">%s</a>" tag tag))
-                                                      (plist-get info :filetags)
-                                                      ", "))))
-                                 ,(when (equal "article" (plist-get info :page-type))
-                                    ;; TODO: Link to mailing list
-                                    "<script src=\"https://utteranc.es/client.js\"
+            ,(dw/site-header info)
+            (div (@ (class "container"))
+                 (div (@ (class "row"))
+                      (div (@ (class "col-sm-12 blog-main"))
+                           (div (@ (class "blog-post"))
+                                (h1 (@ (class "blog-post-title"))
+                                    ,(org-export-data (plist-get info :title) info))
+                                (p (@ (class "blog-post-meta"))
+                                   ,(org-export-data (org-export-get-date info "%B %e, %Y") info))
+                                ,contents
+                                ,(let ((tags (plist-get info :filetags)))
+                                   (when (and tags (> (list-length tags) 0))
+                                     `(p (@ (class "blog-post-tags"))
+                                         "Tags: "
+                                         ,(mapconcat (lambda (tag) tag)
+                                                    ;; TODO: We don't have tag pages yet
+                                                    ;; (format "<a href=\"/tags/%s/\">%s</a>" tag tag))
+                                                     (plist-get info :filetags)
+                                                     ", "))))
+                                ,(when (equal "article" (plist-get info :page-type))
+                                   ;; TODO: Link to mailing list
+                                   "<script src=\"https://utteranc.es/client.js\"
                                               repo=\"daviwil/harmonicschemes.com\"
                                               issue-term=\"title\"
                                               label=\"comments\"
@@ -191,7 +196,7 @@
                                               async>
                                      </script>")))))
 
-             ,(dw/site-footer info))))))
+            ,(dw/site-footer info))))))
 
 ;; Thanks Ashraz!
 (defun dw/org-html-link (link contents info)
@@ -290,13 +295,13 @@
 
 (defun dw/generate-sitemap (title list)
   (concat
-    "#+TITLE: " title "\n\n"
-    "#+BEGIN_EXPORT html\n"
-    (mapconcat (lambda (item)
-                 (car item))
-               (cdr list)
-               "\n")
-    "\n#+END_EXPORT\n"))
+   "#+TITLE: " title "\n\n"
+   "#+BEGIN_EXPORT html\n"
+   (mapconcat (lambda (item)
+                (car item))
+              (cdr list)
+              "\n")
+   "\n#+END_EXPORT\n"))
 
 (setq org-html-preamble  #'dw/site-header
       org-html-postamble #'dw/site-footer


### PR DESCRIPTION
This PR seeks to add two installation guides for GNU Guix, a recommended nonguix one, and a free (as in freedom) standard CLI installation. The GNU Guix index page has also been overhauled, including some quick information, references to the FAQs page, and (eventually) some featured articles and news related to GNU Guix.

The FAQs page holds just that, frequently asked questions related to GNU Guix as both an OS and a package manager, how to use nonfree software on GNU Guix, and questions along those lines. 