### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,27 @@
+name: Check
+on: [push]
+jobs:
+  Elisp-checks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        check:
+          - load-file
+          - checkdoc
+    steps:
+      - uses: actions/checkout@v2
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 27.2
+      - uses: leotaku/elisp-check@master
+        with:
+          check: ${{ matrix.check }}
+          file: publish.el
+  Check-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 27.2
+      - run: ./local-build.sh


### PR DESCRIPTION
In order to make sure that any PR on GitHub keeps the publishing process intact, GitHub workflows/actions are there to save the day.

This commit introduces two jobs:

## Elisp-checks
This check uses the leotaku/elisp-check action to ensure that the file can get loaded by emacs and that the documentation follows best practices. Please note that there are a lot of warnings currently on `checkdoc`. We could set `warnings_as_errors` to `true`, but that is probably better *after* we made sure that those errors are gone first.

## Check-publish
This is a sanity check to ensure that `./local-build.sh` finishes without any errors.