### PR TITLE
convert emacs help shorcuts into a table

### DIFF
--- a/content/emacs/help-cheatsheet.org
+++ b/content/emacs/help-cheatsheet.org
@@ -11,13 +11,16 @@ Emacs is self documented, the code's documentation is searchable, accessible wit
 
 Here are the most helpful shortcuts to reach the Emacs help system:
 
-**  C-h i -- User guide for emacs and important modes (command: info)
-Also displays Linux tools [[https://en.wikipedia.org/wiki/Info_(Unix)][info pages]]
-** C-h r -- Emacs User Manual (command: info-emacs-manual)
-** C-h f -- show detailed information about functions and commands (command: describe-function)
-** C-h v -- variables detailed information (command: describe-variable)
-** C-h b -- describes the enabled key bindings with the functions/commands they call (command: describe-bindings)
-** C-h m -- describes the current major mode enabled with all enabled minor modes (command: describe-mode)
- Also lists key bindings
-** C-h a -- Search documentation related to a command (command: apropos-command)
-** C-h d -- Search documentation for a specific keyword (command: apropos-documentation)
+| Key   | command              | Purpose                                                                             |
+|-------+----------------------+-------------------------------------------------------------------------------------|
+| C-h i | info                 | User guide for emacs and important modes                                            |
+|       |                      | Also displays Linux tools [[https://en.wikipedia.org/wiki/Info_(Unix)][info pages]] |
+| C-h r | info-emacs-manual    | Emacs User Manual                                                                   |
+| C-h f | describe-function    | show detailed information about functions and commands                              |
+| C-h v | describe-variable    | variables detailed information                                                      |
+| C-h b | describe-bindings    | describes the enabled key bindings with the functions/commands they call            |
+| C-h m | describe-mode        | describes the current major mode enabled with all enabled minor modes               |
+|       |                      | Also lists key bindings                                                             |
+| C-h a | apropos-command      | Search documentation related to a command                                           |
+| C-h d | apropos-documentaion | Search documentation for a specific keyword                                         |
+


### PR DESCRIPTION
This reverts commit 89fdf34267f8872e9c61b7b6045e99fb0ccbca82.

the issue has since been fixed, I'm reverting it back to a table, as it was before
