### PR TITLE
handle nil content within table cells

### DIFF
--- a/publish.el
+++ b/publish.el
@@ -307,8 +307,9 @@ Note that any hline TABLE-ROW will be removed."
 
 (defun bk/org-minimal--table-cell (_table-cell contents _info)
   "Wraps the table-cell's CONTENTS in <td> tags."
-  (format "<td>%s</td>" contents))
-
+  ;;(format "<td>%s</td>" contents))
+  (format "<td>%s</td>" (if contents contents "")))
+
 (org-export-define-derived-backend 'site-html
     'slimhtml
   :translate-alist


### PR DESCRIPTION
this pr fixes an issue in table rendering. When values are empty, the rendered value is "nil" instead of a blank string