### PR TITLE
temp fix to missing ox-slimhtml in melpa

### DIFF
--- a/local-build.sh
+++ b/local-build.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
+
+test ! -d .packages/ox-slimhtml && git clone https://github.com/balddotcat/ox-slimhtml .packages/ox-slimhtml
 emacs -q --batch -l ./publish.el --funcall dw/publish

--- a/publish.el
+++ b/publish.el
@@ -59,8 +59,10 @@
 (use-package esxml
   :ensure t)
 
+;;; temp fix to ox-slimhtml no longer being available on melpa
+(add-to-list 'load-path ".packages/ox-slimhtml")
 (use-package ox-slimhtml
-  :ensure t)
+  :ensure nil)
 
 (use-package ox-gemini
   :ensure t)


### PR DESCRIPTION
ox-slimhml is no longer in melpa and it breaks publishing of the wiki

this is really a late night fix, but should keep this thing working until we find a permanent solution.